### PR TITLE
Add: Add workflow for releases

### DIFF
--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -1,0 +1,33 @@
+name: Release Python package with pontos
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+
+jobs:
+  build-and-release:
+    name: Create a new release with pontos
+    # If the event is a workflow_dispatch or the label 'make release' is set and PR is closed because of a merge
+    if: (github.event_name == 'workflow_dispatch') || (contains( github.event.pull_request.labels.*.name, 'make release') && github.event.pull_request.merged == true)
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Setting the Reference
+        run: |
+          if [[ "${{ github.event_name }}" = "workflow_dispatch" ]]; then
+            echo "RELEASE_REF=${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "RELEASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
+          fi
+      - name: Release with release action
+        uses: greenbone/actions/release@v2
+        with:
+          conventional-commits: true
+          github-user: ${{ secrets.GREENBONE_BOT }}
+          github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}
+          github-user-token: ${{ secrets.GREENBONE_BOT_TOKEN }}
+          gpg-key: ${{ secrets.GPG_KEY }}
+          gpg-fingerprint: ${{ secrets.GPG_FINGERPRINT }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          strategy: calendar
+          ref: ${{ env.RELEASE_REF }}


### PR DESCRIPTION
## What

Add workflow for releases

## Why

Allow to create releases from the beginning of the start of a project.

## References

DEVOPS-547


