### PR TITLE
Fix: Autohook isort plugin typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ exclude = '''
 
 [tool.autohooks]
 mode = "poetry"
-pre-commit = ["autohooks.plugins.black",  "autohooks.plugin.isort", "autohooks.plugins.pylint"]
+pre-commit = ["autohooks.plugins.black",  "autohooks.plugins.isort", "autohooks.plugins.pylint"]
 
 [tool.pontos.version]
 version-module-file = "<FIXME>/__version__.py"


### PR DESCRIPTION
## What

Currently the autohook plugin for isort does not work because of a typo

## Why

<!-- Describe why are these changes necessary? -->

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


