### PR TITLE
Fix: Warning in pylint regarding overgeneral-exceptions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -465,4 +465,4 @@ valid-metaclass-classmethod-first-arg=mcs
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception


### PR DESCRIPTION
## What
This PR fixes a warning in pylint regarding `overgeneral-exceptions`.

## Why
To get rid off:
```
➜  python-project-template git:(main) poetry run pylint .
pylint: Command line or configuration file:1: UserWarning: Specifying exception names in the overgeneral-exceptions option without module name is deprecated and support for it will be removed in pylint 3.0. Use fully qualified name (maybe 'builtins.Exception' ?) instead.
```

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


