### PR TITLE
Change: Use new dev dependency group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7.2"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pontos = ">=22.10.0"
 autohooks = ">=22.8.0"
 autohooks-plugin-black = ">=22.8.0"


### PR DESCRIPTION
## What
This PR changes the pyproject.toml to use the new dev dependency group `tool.poetry.group.dev.dependencies` instead of `tool.poetry.dev-dependencies`.

## Why
As of Poetry 1.2, this new syntax is recommended (see https://python-poetry.org/docs/master/managing-dependencies/#dependency-groups). The old syntax is still supported, but is to be deprecated in the future.
For new projects using this template, we should recommend using the new syntax.
If a user would add a dev dependency without having this new dev dependency group, it'll be created automatically so that thee are both the old and new group, which is quite ugly IMHO.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


