### PR TITLE
Fix: Conventional commits for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
       python-packages:
         patterns:
           - "*"
+    commit-message:
+      prefix: "Deps"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -22,3 +24,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    commit-message:
+      prefix: "Deps"


### PR DESCRIPTION
## What
The conventional commits check currently fails for Dependabot PRs, because it doesn't use the `Deps` prefix.

## Why
To make Dependabot PRs pass the check for conventional commits.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


